### PR TITLE
Nuovo layout m5s.html, corretto start_notify.sh

### DIFF
--- a/app/main/_layout/m5s.html
+++ b/app/main/_layout/m5s.html
@@ -1,11 +1,17 @@
-<html>
+<!DOCTYPE html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta name="viewport" content="width=device-width" />
     <title> <!-- WEBMCP SLOTNODIV html_title --></title>
     <link rel="stylesheet" type="text/css" media="screen" href="__BASEURL__/static/trace.css" />
     <link rel="stylesheet" type="text/css" media="screen" href="__BASEURL__/static/gregor.js/gregor.css" />
-    <link rel="stylesheet" type="text/css" media="screen" href="<!-- WEBMCP SLOTNODIV stylesheet_url -->" />
+    
+    <!--  Movimento5Stelle -->
+    <link rel="stylesheet" type="text/css" media="screen" href="__BASEURL__/static/buttons.css"/>
+     
+    	
+    <link rel="stylesheet" type="text/css" media="screen" href="__BASEURL__/static/m5s.css" />
+    <link rel="stylesheet" type="text/css" media="screen" href="<!-- WEBMCP SLOTNODIV stylesheet_url -->" /> 
     <!-- WEBMCP SLOTNODIV html_head -->
     <script type="text/javascript">jsFail = true;</script>
     <![if !IE]>
@@ -13,6 +19,7 @@
     <![endif]>
     <script type="text/javascript" src="__BASEURL__/static/js/jsprotect.js"></script>
     <script type="text/javascript" src="__BASEURL__/static/js/partialload.js"></script>
+    <script type="text/javascript" src="__BASEURL__/static/js/jquery-1.9.1.min.js"></script>
     <script type="text/javascript">var ui_tabs_active = {};</script>
   </head>
   <body>
@@ -60,8 +67,10 @@
         close
       </div>
     </div>
+   
     <script type="text/javascript">
     <!-- WEBMCP SLOTNODIV custom_script -->
     </script>
+     
   </body>
 </html>

--- a/config/myconfig.lua
+++ b/config/myconfig.lua
@@ -260,5 +260,6 @@ config.enable_debug_trace = true
 -- ========================================================================
 -- Do main initialisation (DO NOT REMOVE FOLLOWING SECTION)
 -- ========================================================================
+slot.set_layout("m5s")
 
 execute.config("init")

--- a/extras/myconfig.lua
+++ b/extras/myconfig.lua
@@ -260,5 +260,6 @@ config.enable_debug_trace = true
 -- ========================================================================
 -- Do main initialisation (DO NOT REMOVE FOLLOWING SECTION)
 -- ========================================================================
+slot.set_layout("m5s")
 
 execute.config("init")

--- a/extras/start_notify.sh
+++ b/extras/start_notify.sh
@@ -3,6 +3,7 @@ RET=`ps aux | grep 'Event:send_notifications_loop()'|grep -v grep`
 
 if [ "z${RET}" != "z" ]; then
 	echo "Daemon already running.."
+        rm nohup.out 2>/dev/null
 	exit 1
 else
 	nohup  su - www-data -c 'cd /opt/liquid_feedback_frontend/;echo "Event:send_notifications_loop()" | ../webmcp/bin/webmcp_shell myconfig' 2>/dev/null&


### PR DESCRIPTION
Ripristinato default layout e inserito layout m5s.html in myconfig.lua richiamando la funzione slot.set_layout().

Nota: Reinstallare con "extras/install -a" (senza l'opzione -c, in modo da caricare il nuovo file di configurazione)

modified:   app/main/_layout/default.html
new file:   app/main/_layout/m5s.html
modified:   config/myconfig.lua

Corretto start script del notifier
modified:   extras/myconfig.lua
modified:   extras/start_notify.sh
